### PR TITLE
chore: update remark linting to current versions

### DIFF
--- a/.github/remark.yaml
+++ b/.github/remark.yaml
@@ -1,4 +1,6 @@
 plugins:
+# GitHub Flavored Markdown
+  - remark-gfm
 # Check links
   - validate-links
 # Apply some recommended defaults for consistency
@@ -37,7 +39,7 @@ plugins:
   - - remark-lint-unordered-list-marker-style
     - '-'
   - - remark-lint-list-item-indent
-    - space 
+    - 'one'
 # Tables
   - remark-lint-table-pipes
   - remark-lint-no-literal-urls

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ Date of sensor calibration data used. Formatted according to [https://datatracke
 The following types should be used as applicable `rel` types in the
 [Link Object](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md#link-object).
 
-| Type                | Description |
-| ------------------- | ----------- |
-| interior-orientation      | This link points to json document with an [InteriorOrientation](#interiororientation) object. |
+| Type                 | Description |
+| -------------------- | ----------- |
+| interior-orientation | This link points to json document with an [InteriorOrientation](#interiororientation) object. |
 
 ## Best practices
 - Use rotation matrix in preference of omega, phi and kappa

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "format-examples": "stac-node-validator . --format --schemaMap https://stac-extensions.github.io/perspective-imagery/v1.0.0/schema.json=./json-schema/schema.json"
   },
   "dependencies": {
-    "remark-cli": "^8.0.0",
-    "remark-lint": "^7.0.0",
-    "remark-lint-no-html": "^2.0.0",
-    "remark-preset-lint-consistent": "^3.0.0",
-    "remark-preset-lint-markdown-style-guide": "^3.0.0",
-    "remark-preset-lint-recommended": "^4.0.0",
-    "remark-validate-links": "^10.0.0",
+    "remark-cli": "^12.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-lint": "^10.0.1",
+    "remark-lint-no-html": "^4.0.1",
+    "remark-preset-lint-consistent": "^6.0.1",
+    "remark-preset-lint-markdown-style-guide": "^6.0.1",
+    "remark-preset-lint-recommended": "^7.0.1",
+    "remark-validate-links": "^13.1.0",
     "stac-node-validator": "^1.0.0"
   }
 }


### PR DESCRIPTION
This avoids some noise during `npm install`